### PR TITLE
Adding Initialization and Component Loading functions

### DIFF
--- a/packages/ef-runtime-client/README.md
+++ b/packages/ef-runtime-client/README.md
@@ -1,0 +1,25 @@
+# Extensible Frontends Runtime Client
+
+Helps host apps initialize the runtime on the client side and load components exisiting in the component registry.
+
+## Usage
+
+### Initialization
+
+```js
+import * as EFRuntime from 'ef-runtime-client'
+
+EFRuntime.init();
+```
+
+or you can override specific entries in the component registry as follows:
+
+```js
+EFRuntime.init({ 'my-component': 'http://localhost:3000' });
+```
+
+### Loading a component
+
+```js
+EFRuntime.load('my-component');
+```

--- a/packages/ef-runtime-client/index.js
+++ b/packages/ef-runtime-client/index.js
@@ -1,0 +1,39 @@
+const EFRegistry = {};
+
+export function init(overrides = {}) {
+  // Add SystemJS script tag
+  const systemJSScript = document.createElement("script");
+  systemJSScript.src =
+    "https://cdnjs.cloudflare.com/ajax/libs/systemjs/6.14.2/system.min.js";
+  document.head.append(systemJSScript);
+
+  // TODO fetch from component registry
+
+  // Add overrides
+  Object.assign(EFRegistry, overrides);
+
+  // TODO read overrides from config file if exists
+}
+
+export function load(component) {
+  const componentURL = EFRegistry[component];
+
+  if (componentURL === undefined) {
+    console.error(
+      `Component ${component} was not found in the Component Registry`
+    );
+    return null;
+  }
+
+  // Add Demo Component JS script
+  const componentScript = document.createElement("script");
+  componentScript.type = "systemjs-module";
+  componentScript.src = `${componentURL}/js`;
+  document.head.append(componentScript);
+
+  // Add Demo Component CSS
+  const componentCSS = document.createElement("link");
+  componentCSS.rel = "stylesheet";
+  componentCSS.href = `${componentURL}/css`;
+  document.head.append(componentCSS);
+}


### PR DESCRIPTION
This PR adds the basic structure for the runtime for now.
It provides two main functionalities:

Initialization:

- initialize the system-js and add the related script tag.
- fetches the component registry and parse it. Each component is mapped to its base-url
- (optional) override specific entries of the component registry

Loading a component:

- create a script tag with src set to the /js endpoint provided by the component
- create a link tag with href set to the /css endpoint provided by the component.

TODO:
- [ ] fetch the component registry from a URL (possibly setup from ENV variables??)
- [ ] add JSDoc for documentation
- [ ] publish to npm 
- [ ] check for licensing, security, ... etc