### PR TITLE
Fetch files from the component registry

### DIFF
--- a/packages/ef-runtime-client/README.md
+++ b/packages/ef-runtime-client/README.md
@@ -1,0 +1,25 @@
+# Extensible Frontends Runtime Client
+
+Helps host apps initialize the runtime on the client side and load components exisiting in the component registry.
+
+## Usage
+
+### Initialization
+
+```js
+import * as EFRuntime from 'ef-runtime-client'
+
+EFRuntime.init();
+```
+
+or you can override specific entries in the component registry as follows:
+
+```js
+EFRuntime.init({ 'my-component': 'http://localhost:3000' });
+```
+
+### Loading a component
+
+```js
+EFRuntime.load('my-component');
+```

--- a/packages/ef-runtime-client/README.md
+++ b/packages/ef-runtime-client/README.md
@@ -9,13 +9,18 @@ Helps host apps initialize the runtime on the client side and load components ex
 ```js
 import * as EFRuntime from 'ef-runtime-client'
 
-EFRuntime.init();
+EFRuntime.init({ systemCode: 'ef-demo-host'});
 ```
 
 or you can override specific entries in the component registry as follows:
 
 ```js
-EFRuntime.init({ 'my-component': 'http://localhost:3000' });
+EFRuntime.init({
+  systemCode: 'ef-demo-host'
+  overrides: {
+    'my-component': 'http://localhost:3000'
+  }
+});
 ```
 
 ### Loading a component

--- a/packages/ef-runtime-client/index.js
+++ b/packages/ef-runtime-client/index.js
@@ -1,0 +1,39 @@
+const EFRegistry = {};
+
+export function init(overrides = {}) {
+  // Add SystemJS script tag
+  const systemJSScript = document.createElement("script");
+  systemJSScript.src =
+    "https://cdnjs.cloudflare.com/ajax/libs/systemjs/6.14.2/system.min.js";
+  document.head.append(systemJSScript);
+
+  // TODO fetch from component registry
+
+  // Add overrides
+  Object.assign(EFRegistry, overrides);
+
+  // TODO read overrides from config file if exists
+}
+
+export function load(component) {
+  const componentURL = EFRegistry[component];
+
+  if (componentURL === undefined) {
+    console.error(
+      `Component ${component} was not found in the Component Registry`
+    );
+    return null;
+  }
+
+  // Add Demo Component JS script
+  const componentScript = document.createElement("script");
+  componentScript.type = "systemjs-module";
+  componentScript.src = `${componentURL}/js`;
+  document.head.append(componentScript);
+
+  // Add Demo Component CSS
+  const componentCSS = document.createElement("link");
+  componentCSS.rel = "stylesheet";
+  componentCSS.href = `${componentURL}/css`;
+  document.head.append(componentCSS);
+}

--- a/packages/ef-runtime-client/index.js
+++ b/packages/ef-runtime-client/index.js
@@ -1,16 +1,31 @@
 const EFRegistry = {};
+const EFRegistryBaseURL =
+  "https://ef-component-registry-51742754f2eb.herokuapp.com";
 
-export function init(overrides = {}) {
+export async function init(options = {}) {
+  if (options.systemCode === undefined) {
+    throw new Error("Must provide a 'systemCode' option");
+  }
   // Add SystemJS script tag
   const systemJSScript = document.createElement("script");
   systemJSScript.src =
     "https://cdnjs.cloudflare.com/ajax/libs/systemjs/6.14.2/system.min.js";
   document.head.append(systemJSScript);
 
-  // TODO fetch from component registry
+  // fetch from component registry
+  try {
+    const res = await fetch(`${EFRegistryBaseURL}/?app=${options.systemCode}`);
+    const data = await res.json();
+    Object.assign(EFRegistry, data.imports);
+  } catch (err) {
+    console.error(`Unable to fetch Component Registry`);
+    console.log(err);
+  }
 
   // Add overrides
-  Object.assign(EFRegistry, overrides);
+  options.overrides &&
+    typeof options.overrides == "object" &&
+    Object.assign(EFRegistry, options.overrides);
 
   // TODO read overrides from config file if exists
 }


### PR DESCRIPTION
This PR works on fetching the component registry import map from the component registry URL.
It also add `systemCode` as a required option for he initialization of the runtime. 

An example of usage in the host app would be as follows:
```js
await EFRuntime.init({
  systemCode: 'ef-demo-host'
});

EFRuntime.load('ef-demo-component');
```