### PR TITLE
Bundling SystemJS instead of using CDN

### DIFF
--- a/packages/ef-runtime-client/package.json
+++ b/packages/ef-runtime-client/package.json
@@ -17,7 +17,7 @@
   "devDependencies": {
     "@types/jest": "^29.5.6",
     "@types/node": "^20.6.5",
-    "@types/systemjs": "^6.13.3",
+    "@types/systemjs": "^6.13.4",
     "jest": "^29.7.0",
     "ts-jest": "^29.1.1"
   },

--- a/packages/ef-runtime-client/src/EFRuntime/EFRuntime.test.ts
+++ b/packages/ef-runtime-client/src/EFRuntime/EFRuntime.test.ts
@@ -1,6 +1,6 @@
 import { EFRuntime, IRuntimeDependencies } from "./EFRuntime";
-import { IComponentRegistry } from "../ComponentRegistry";
-import { ModuleLoader, IModuleLoaderDependencies } from "../ModuleLoader";
+import { ComponentRegistry, IComponentRegistry } from "../ComponentRegistry";
+import { ModuleLoader } from "../ModuleLoader";
 import { StylingHandler } from "../StylingHandler";
 
 class MockStylingHandler extends StylingHandler {
@@ -11,7 +11,7 @@ class MockStylingHandler extends StylingHandler {
 }
 
 class MockModuleLoader extends ModuleLoader {
-  constructor(dependencies: IModuleLoaderDependencies) {
+  constructor(dependencies: IComponentRegistry) {
     super(dependencies);
   }
   init = jest.fn();
@@ -41,12 +41,13 @@ describe("EFRuntime", () => {
       },
     } as unknown as Document;
 
-    const moduleLoaderDependencies: IModuleLoaderDependencies = {
-      document: mockDocument,
-      loaderSrc: "someSrc",
+    const registryDependencies = {
+      registryURL: "https://ef-component-registry-51742754f2eb.herokuapp.com",
     };
 
-    mockModuleLoader = new MockModuleLoader(moduleLoaderDependencies);
+    const registry = new ComponentRegistry(registryDependencies);
+
+    mockModuleLoader = new MockModuleLoader(registry);
     mockStylingHandler = new MockStylingHandler(mockDocument);
 
     dependencies = {

--- a/packages/ef-runtime-client/src/EFRuntime/EFRuntime.ts
+++ b/packages/ef-runtime-client/src/EFRuntime/EFRuntime.ts
@@ -40,14 +40,13 @@ export class EFRuntime {
   ): Promise<void> {
     this.validateOptions(options);
 
-    await Promise.all([
-      this.moduleLoader.init(),
-      this.registry.fetch(options.systemCode as string),
-    ]);
+    await this.registry.fetch(options.systemCode as string);
 
     if (options.overrides) {
       this.registry.applyOverrides(options.overrides);
     }
+
+    await this.moduleLoader.init();
 
     this.loadAll();
   }

--- a/packages/ef-runtime-client/src/ModuleLoader/ModuleLoader.test.ts
+++ b/packages/ef-runtime-client/src/ModuleLoader/ModuleLoader.test.ts
@@ -1,10 +1,10 @@
-import { ModuleLoader, IModuleLoaderDependencies } from "./ModuleLoader";
+import { ComponentRegistry } from "../ComponentRegistry";
+import { ModuleLoader } from "./ModuleLoader";
 
 describe("ModuleLoader", () => {
   let createElementMock: jest.Mock;
   let appendMock: jest.Mock;
   let moduleLoader: ModuleLoader;
-  let moduleLoaderDependencies: IModuleLoaderDependencies;
 
   beforeEach(() => {
     createElementMock = jest.fn();
@@ -15,13 +15,13 @@ describe("ModuleLoader", () => {
       head: { append: appendMock },
     }) as unknown as Document;
 
-    moduleLoaderDependencies = {
-      document: global.document,
-      loaderSrc:
-        "https://cdnjs.cloudflare.com/ajax/libs/systemjs/6.14.2/system.min.js",
+    const registryDependencies = {
+      registryURL: "https://ef-component-registry-51742754f2eb.herokuapp.com",
     };
 
-    moduleLoader = new ModuleLoader(moduleLoaderDependencies);
+    const registry = new ComponentRegistry(registryDependencies);
+
+    moduleLoader = new ModuleLoader(registry);
   });
 
   it("should initialize the module loader", async () => {

--- a/packages/ef-runtime-client/src/ModuleLoader/ModuleLoader.ts
+++ b/packages/ef-runtime-client/src/ModuleLoader/ModuleLoader.ts
@@ -1,29 +1,19 @@
-export interface IModuleLoaderDependencies {
-  document: Document;
-  loaderSrc: string;
-}
+import { IComponentRegistry } from "../ComponentRegistry";
 
 export class ModuleLoader {
-  private document: Document;
-  private loaderSrc: string;
+  private componentRegistry;
 
-  constructor({ document, loaderSrc }: IModuleLoaderDependencies) {
-    this.document = document;
-    this.loaderSrc = loaderSrc;
+  constructor(componentRegistry: IComponentRegistry) {
+    this.componentRegistry = componentRegistry;
   }
 
   async init(): Promise<void> {
     return new Promise((resolve, reject) => {
-      const script = this.document.createElement("script");
-      script.addEventListener("load", () => resolve());
-      script.addEventListener("error", reject);
-      script.src = this.loaderSrc;
-      this.document.head.append(script);
+      resolve();
     });
   }
 
   async importModule(url: string): Promise<any> {
-    // @ts-ignore
-    return global.System.import(url);
+    return System.import(url);
   }
 }

--- a/packages/ef-runtime-client/src/ModuleLoader/index.ts
+++ b/packages/ef-runtime-client/src/ModuleLoader/index.ts
@@ -1,1 +1,1 @@
-export { ModuleLoader, IModuleLoaderDependencies } from "./ModuleLoader";
+export { ModuleLoader } from "./ModuleLoader";

--- a/packages/ef-runtime-client/src/index.ts
+++ b/packages/ef-runtime-client/src/index.ts
@@ -1,5 +1,5 @@
 import { ComponentRegistry } from "./ComponentRegistry";
-import { ModuleLoader, IModuleLoaderDependencies } from "./ModuleLoader";
+import { ModuleLoader } from "./ModuleLoader";
 import { EFRuntime, IRuntimeDependencies } from "./EFRuntime";
 import { StylingHandler } from "./StylingHandler";
 
@@ -9,13 +9,7 @@ const registryDependencies = {
 
 const registry = new ComponentRegistry(registryDependencies);
 
-const moduleLoaderDependencies: IModuleLoaderDependencies = {
-  document: document,
-  loaderSrc:
-    "https://cdnjs.cloudflare.com/ajax/libs/systemjs/6.14.2/system.min.js",
-};
-
-const moduleLoader = new ModuleLoader(moduleLoaderDependencies);
+const moduleLoader = new ModuleLoader(registry);
 
 const stylingHandler = new StylingHandler(document);
 


### PR DESCRIPTION
This PR is for researching ways to bundle SystemJS instead of relying on CDN. It's still not working currently. 
The error you get when testing with `ef-demo-host` is 

```
Cannot find module 'https://ef-demo-component-1459027f3d72.herokuapp.com/js'
```

Using things like `import System from "systemjs/dist/anyfile"` has to be used with adding `@ts-ignore` boefore it to be able to build with typescript. However, this still doesn't work as expected when built in the demo-host for some reason and you will get `Type Error`.

 Inspecting the `System` object in the browser console shows only an `import` method and nothing else. Probably the webpack optimizes the build somehow.