### PR TITLE
Fix publish not updating apps version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,6 +30,10 @@ jobs:
           command: |
             npm install
       - run:
+          name: Set version
+          command: |
+            npm version --workspaces ${CIRCLE_TAG}
+      - run:
           name: Build
           command: |
             npm run build --workspaces --if-present


### PR DESCRIPTION
## What
Set npm version in each package before publishing a new version

## Why
Publish failed the last time because we already have a v1.0.0 published on npm, we need to bump the version of each package before publishing it.
