### PR TITLE
[Ef-37] Support for Separate JS and CSS URLs in Runtime Client

### DIFF
--- a/packages/ef-runtime-client/README.md
+++ b/packages/ef-runtime-client/README.md
@@ -1,30 +1,69 @@
 # Extensible Frontends Runtime Client
 
-Helps host apps initialize the runtime on the client side and load components exisiting in the component registry.
+A runtime library designed to help host apps initialise the runtime on the client-side and dynamically load components from an external component registry.
+
+## Table of Contents
+
+- [About](#about)
+- [Getting Started](#getting-started)
+  - [Prerequisites](#prerequisites)
+  - [Installation](#installation)
+- [Usage](#usage)
+  - [Initialisation](#initialisation)
+- [Running Tests](#running-tests)
+- [FAQ](#faq)
+
+## About
+
+This client-side runtime library is part of the Extensible Frontends project. It enables host applications to initialise a runtime environment that can dynamically load and manage components from an external component registry.
+
+## Getting Started
+
+### Prerequisites
+
+- Node.js
+- npm or yarn
+
+### Installation
+
+Install the package using npm or yarn:
+
+```bash
+npm install ef-runtime-client
+```
 
 ## Usage
 
-### Initialization
+### Initialisation
+
+To initialise the runtime, provide the system code for your host application:
 
 ```js
-import * as EFRuntime from 'ef-runtime-client'
+import * as EFRuntime from "ef-runtime-client";
 
-EFRuntime.init({ systemCode: 'ef-demo-host'});
+EFRuntime.init({ systemCode: "ef-demo-host" });
 ```
 
-or you can override specific entries in the component registry as follows:
+If needed, you can override specific entries in the component registry. Specify separate URLs for JavaScript and CSS like so:
 
 ```js
 EFRuntime.init({
-  systemCode: 'ef-demo-host'
+  systemCode: "ef-demo-host",
   overrides: {
-    'my-component': 'http://localhost:3000'
-  }
+    "my-component": {
+      js: "http://localhost:3000/my-component.js",
+      css: "http://localhost:3000/my-component.css",
+    },
+  },
 });
 ```
 
-### Loading a component
+## Running Tests
 
-```js
-EFRuntime.load('my-component');
+Execute the test suite with the following command:
+
+```bash
+npm test
 ```
+
+## FAQ

--- a/packages/ef-runtime-client/src/ComponentRegistry/ComponentRegistry.test.ts
+++ b/packages/ef-runtime-client/src/ComponentRegistry/ComponentRegistry.test.ts
@@ -11,12 +11,19 @@ describe("ComponentRegistry", () => {
     global.fetch = jest.fn().mockImplementation(() =>
       Promise.resolve({
         json: () =>
-          Promise.resolve({ imports: { "ef-demo-component": "url" } }),
+          Promise.resolve({
+            imports: {
+              "ef-demo-component": { js: "js-url", css: "css-url" },
+            },
+          }),
       })
     );
 
     await registry.fetch("systemCode");
-    expect(registry.getURL("ef-demo-component")).toBe("url");
+    expect(registry.getURL("ef-demo-component")).toEqual({
+      js: "js-url",
+      css: "css-url",
+    });
   });
 
   it("should get undefined for non-existent component", () => {
@@ -24,15 +31,28 @@ describe("ComponentRegistry", () => {
   });
 
   it("should apply overrides", () => {
-    registry.applyOverrides({ "ef-demo-component": "override-url" });
-    expect(registry.getURL("ef-demo-component")).toBe("override-url");
+    registry.applyOverrides({
+      "ef-demo-component": {
+        js: "override-js-url",
+        css: "override-css-url",
+      },
+    });
+    expect(registry.getURL("ef-demo-component")).toEqual({
+      js: "override-js-url",
+      css: "override-css-url",
+    });
   });
 
-  // New test case for getComponentKeys
   it("should return component keys", () => {
     registry.applyOverrides({
-      "ef-demo-component": "override-url",
-      "another-component": "another-url",
+      "ef-demo-component": {
+        js: "override-js-url",
+        css: "override-css-url",
+      },
+      "another-component": {
+        js: "another-js-url",
+        css: "another-css-url",
+      },
     });
 
     const keys = registry.getComponentKeys();

--- a/packages/ef-runtime-client/src/ComponentRegistry/ComponentRegistry.ts
+++ b/packages/ef-runtime-client/src/ComponentRegistry/ComponentRegistry.ts
@@ -1,9 +1,11 @@
 export interface IComponentRegistry {
   fetch(systemCode: string): Promise<void>;
-  getURL(component: string): string | undefined;
+  getURL(component: string): { js: string; css: string } | undefined;
   getComponentKeys(): string[];
-  applyOverrides(overrides: { [propName: string]: string }): void;
-  getRegistry(): { [key: string]: string };
+  applyOverrides(overrides: {
+    [propName: string]: { js: string; css: string };
+  }): void;
+  getRegistry(): { [key: string]: { js: string; css: string } };
 }
 
 export interface IComponentRegistryDependencies {
@@ -11,7 +13,7 @@ export interface IComponentRegistryDependencies {
 }
 
 export class ComponentRegistry implements IComponentRegistry {
-  private registry: { [propName: string]: string } = {};
+  private registry: { [propName: string]: { js: string; css: string } } = {};
   private registryURL: string;
 
   constructor({ registryURL }: IComponentRegistryDependencies) {
@@ -28,7 +30,7 @@ export class ComponentRegistry implements IComponentRegistry {
     }
   }
 
-  getURL(component: string): string | undefined {
+  getURL(component: string): { js: string; css: string } | undefined {
     return this.registry[component];
   }
 
@@ -36,11 +38,20 @@ export class ComponentRegistry implements IComponentRegistry {
     return Object.keys(this.registry);
   }
 
-  getRegistry(): { [key: string]: string } {
+  getRegistry(): { [key: string]: { js: string; css: string } } {
     return { ...this.registry };
   }
 
-  applyOverrides(overrides: { [propName: string]: string }): void {
-    Object.assign(this.registry, overrides);
+  applyOverrides(overrides: {
+    [propName: string]: { js: string; css: string };
+  }): void {
+    for (const [key, { js, css }] of Object.entries(overrides)) {
+      if (this.registry[key]) {
+        if (js) this.registry[key].js = js;
+        if (css) this.registry[key].css = css;
+      } else {
+        this.registry[key] = { js: js || "", css: css || "" };
+      }
+    }
   }
 }

--- a/packages/ef-runtime-client/src/EFRuntime/EFRuntime.test.ts
+++ b/packages/ef-runtime-client/src/EFRuntime/EFRuntime.test.ts
@@ -65,7 +65,7 @@ describe("EFRuntime", () => {
       );
     });
 
-    it("initializes the module loader and fetches registry", async () => {
+    it("initialises the module loader and fetches registry", async () => {
       await runtime.init({ systemCode: "some-system-code" });
 
       expect(mockModuleLoader.init).toHaveBeenCalled();
@@ -73,7 +73,12 @@ describe("EFRuntime", () => {
     });
 
     it("applies overrides if provided", async () => {
-      const overrides = { "some-component": "some-url" };
+      const overrides = {
+        "some-component": {
+          js: "some-js-url",
+          css: "some-css-url",
+        },
+      };
       await runtime.init({ systemCode: "some-system-code", overrides });
 
       expect(mockRegistry.applyOverrides).toHaveBeenCalledWith(overrides);
@@ -88,16 +93,56 @@ describe("EFRuntime", () => {
       await runtime.load("some-component");
 
       expect(console.error).toHaveBeenCalledWith(
-        "Component some-component was not found in the Component Registry"
+        "Failed to retrieve URL for component some-component"
       );
     });
 
-    it("adds styling if component is found in registry", async () => {
-      mockRegistry.getURL.mockReturnValue("some-url");
+    it("logs an error if js is missing from registry", async () => {
+      mockRegistry.getURL.mockReturnValue({ js: null, css: "some-css-url" });
+      console.error = jest.fn();
 
       await runtime.load("some-component");
 
-      expect(mockStylingHandler.addStyling).toHaveBeenCalledWith("some-url");
+      expect(console.error).toHaveBeenCalledWith(
+        "Missing JS URL for component some-component"
+      );
+    });
+
+    it("logs an error if css is missing from registry", async () => {
+      mockRegistry.getURL.mockReturnValue({ js: "some-js-url", css: null });
+      console.error = jest.fn();
+
+      await runtime.load("some-component");
+
+      expect(console.error).toHaveBeenCalledWith(
+        "Missing CSS URL for component some-component"
+      );
+    });
+
+    it("logs an error if both js and css are missing from registry", async () => {
+      mockRegistry.getURL.mockReturnValue({ js: null, css: null });
+      console.error = jest.fn();
+
+      await runtime.load("some-component");
+
+      expect(console.error).toHaveBeenCalledWith(
+        "Missing JS and CSS URL for component some-component"
+      );
+    });
+
+    it("adds styling and imports module if component is found in registry", async () => {
+      mockRegistry.getURL.mockReturnValue({
+        js: "some-js-url",
+        css: "some-css-url",
+      });
+      mockModuleLoader.importModule.mockResolvedValue({});
+
+      await runtime.load("some-component");
+
+      expect(mockStylingHandler.addStyling).toHaveBeenCalledWith(
+        "some-css-url"
+      );
+      expect(mockModuleLoader.importModule).toHaveBeenCalledWith("some-js-url");
     });
   });
 });

--- a/packages/ef-runtime-client/src/EFRuntime/EFRuntime.ts
+++ b/packages/ef-runtime-client/src/EFRuntime/EFRuntime.ts
@@ -25,7 +25,7 @@ export class EFRuntime {
 
   private validateOptions(options: {
     systemCode?: string;
-    overrides?: { [propName: string]: string };
+    overrides?: { [propName: string]: { js: string; css: string } };
   }): void {
     if (!options.systemCode) {
       throw new Error("Must provide a systemCode option");
@@ -35,7 +35,7 @@ export class EFRuntime {
   async init(
     options: {
       systemCode?: string;
-      overrides?: { [propName: string]: string };
+      overrides?: { [propName: string]: { js: string; css: string } };
     } = {}
   ): Promise<void> {
     this.validateOptions(options);
@@ -62,16 +62,54 @@ export class EFRuntime {
   }
 
   async load(component: string): Promise<void> {
-    const url = this.registry.getURL(component);
-    if (!url) {
-      console.error(
-        `Component ${component} was not found in the Component Registry`
-      );
-      return;
+    const urlInfo = this.getComponentURL(component);
+    if (!urlInfo) return;
+
+    const { js, css } = urlInfo;
+    if (!this.isValidURL(js, css, component)) return;
+
+    await this.loadComponent(js, css, component);
+  }
+
+  private getComponentURL(component: string) {
+    const urlInfo = this.registry.getURL(component);
+    if (!urlInfo) {
+      console.error(`Failed to retrieve URL for component ${component}`);
     }
-    this.stylingHandler.addStyling(url);
+    return urlInfo;
+  }
+
+  private isValidURL(
+    js: string | null,
+    css: string | null,
+    component: string
+  ): boolean {
+    let isValid = true;
+    let missingParts: string[] = [];
+
+    if (!js) {
+      missingParts.push("JS");
+      isValid = false;
+    }
+
+    if (!css) {
+      missingParts.push("CSS");
+      isValid = false;
+    }
+
+    if (!isValid) {
+      console.error(
+        `Missing ${missingParts.join(" and ")} URL for component ${component}`
+      );
+    }
+
+    return isValid;
+  }
+
+  private async loadComponent(js: string, css: string, component: string) {
+    this.stylingHandler.addStyling(css);
     try {
-      const componentModule = await this.moduleLoader.importModule(`${url}/js`);
+      const componentModule = await this.moduleLoader.importModule(js);
       this.executeLifecycleMethods(componentModule);
     } catch (error) {
       console.error(

--- a/packages/ef-runtime-client/src/StylingHandler/StylingHandler.test.ts
+++ b/packages/ef-runtime-client/src/StylingHandler/StylingHandler.test.ts
@@ -24,12 +24,13 @@ describe("StylingHandler", () => {
     const linkElement: { rel?: string; href?: string } = {};
     createElementMock.mockReturnValue(linkElement);
 
-    stylingHandler.addStyling("http://example.com");
+    const testUrl = "http://example.com";
+    stylingHandler.addStyling(testUrl);
 
     expect(createElementMock).toHaveBeenCalledWith("link");
     expect(linkElement).toEqual({
       rel: "stylesheet",
-      href: "http://example.com/css",
+      href: testUrl,
     });
     expect(appendMock).toHaveBeenCalledWith(linkElement);
   });

--- a/packages/ef-runtime-client/src/StylingHandler/StylingHandler.ts
+++ b/packages/ef-runtime-client/src/StylingHandler/StylingHandler.ts
@@ -12,7 +12,7 @@ export class StylingHandler implements IStylingHandler {
   addStyling(url: string): void {
     const componentCSS = this.document.createElement("link");
     componentCSS.rel = "stylesheet";
-    componentCSS.href = `${url}/css`;
+    componentCSS.href = url;
     this.document.head.append(componentCSS);
   }
 }

--- a/packages/ef-runtime-client/src/index.ts
+++ b/packages/ef-runtime-client/src/index.ts
@@ -29,7 +29,7 @@ const runtime = new EFRuntime(runtimeDependencies);
 
 export async function init(options: {
   systemCode: string;
-  overrides?: { [propName: string]: string };
+  overrides?: { [propName: string]: { js: string; css: string } };
 }) {
   await runtime.init(options);
 }


### PR DESCRIPTION
#### Description:

This PR aims to address the requirements of the ticket "Separate our URLs for CSS and JS." With this change, the runtime client is now capable of reading separate URLs for JavaScript and CSS files from the component registry.

The component registry will provide the following structure:

```json
{
  "imports": {
    "componentName": {
      "js": "https://external-app.com/components/componentName.js",
      "css": "https://external-app.com/components/componentName.css"
    },
    "componentName2": {
      "js": "https://external-app.com/components/componentName2.js",
      "css": "https://external-app.com/components/componentName2.css"
    },
    "componentName3": {
      "js": "https://external-app.com/components/componentName3.js",
      "css": "https://external-app.com/components/componentName3.css"
    }
  }
}
```

This enhancement ensures greater flexibility in how we load and utilise components, fulfilling both testing and production use-cases.

Please review the changes and provide your feedback.