### PR TITLE
feat: Bumping up the version to 1.2.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@financial-times/ef-runtime",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "private": true,
   "description": "",
   "main": "index.js",

--- a/packages/ef-runtime-client/package.json
+++ b/packages/ef-runtime-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ef-runtime-client",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
This PR bumps up the version to 1.2.1 both on the `ef-runtime-client` package and in the workspace `package.json`.