### PR TITLE
Include cookie in registry request

### DIFF
--- a/packages/ef-runtime-client/src/ComponentRegistry/ComponentRegistry.ts
+++ b/packages/ef-runtime-client/src/ComponentRegistry/ComponentRegistry.ts
@@ -28,7 +28,9 @@ export class ComponentRegistry implements IComponentRegistry {
 
   async fetch(systemCode: string): Promise<void> {
     try {
-      const res = await fetch(`${this.registryURL}/?app=${systemCode}`);
+      const res = await fetch(`${this.registryURL}/?app=${systemCode}`, {
+        credentials: "include",
+      });
       const data = await res.json();
       Object.assign(this.registry, data.imports);
       this.initialised = true;


### PR DESCRIPTION
Recently, the EF registry was recently updated to allow components to declare Ammit flags that decide whether they're shown or hidden (https://github.com/Financial-Times/ef-component-registry/commit/a23253463f1aa4b4874fdd538fac78277be307c1).

The registry makes a request to the Ammit API with the user's FTSession_s token, and it gets back all Ammit flag allocations for the user. These flags are compared to components' Ammit config (if any).

However, currently, the `fetch` to the registry doesn't include the user's cookies, so this Ammit API request won't have the info it needs.

This PR, along with a complementary PR in the registry (https://github.com/Financial-Times/ef-component-registry/pull/24), should fix this.
